### PR TITLE
同步配置界面新增默认权限分组选项

### DIFF
--- a/ldap/doc/en.yaml
+++ b/ldap/doc/en.yaml
@@ -21,7 +21,7 @@ install: |
 releases:
   1.3.2
     zentao:
-      compatible: 12.3.stable
+      compatible: 12.3.stable,12.5.3
       incompatible:
     charge: free
     date: 2020-08-10
@@ -29,7 +29,8 @@ releases:
     depends: null
     license: LGPL
     changelog: >
-      1. 支持12.3
+      1. 支持12.3,12.5.3
+      2. 新增同步ldap用户设置默认权限分组
   1.3.1
     zentao:
       compatible: 11.5.stable
@@ -67,7 +68,7 @@ releases:
       3. 修复设置页面的测试服务器及账号是否可用
   1.2:
     zentao:
-      compatible: 7.0,7.1,7.2,7.2.4,7.2.5,7.3
+      compatible: 7.0,7.1,7.2,7.2.4,7.2.5,7.3,12.3,12.5.3
       incompatible:
     charge: free
     date: 2015-10-16

--- a/ldap/doc/zh-cn.yaml
+++ b/ldap/doc/zh-cn.yaml
@@ -21,7 +21,7 @@ install: |
 releases:
   1.3.2
     zentao:
-      compatible: 12.3.stable
+      compatible: 12.3.stable,12.5.3
       incompatible:
     charge: free
     date: 2020-08-10
@@ -29,7 +29,8 @@ releases:
     depends: null
     license: LGPL
     changelog: >
-      1. 支持12.3
+      1. 支持12.3,12.5.3
+      2. 新增同步ldap用户设置默认权限分组
   1.3.1
     zentao:
       compatible: 11.5.stable
@@ -67,7 +68,7 @@ releases:
       3. 修复设置页面的测试服务器及账号是否可用
   1.2:
     zentao:
-      compatible: 7.0,7.1,7.2,7.2.4,7.2.5,7.3
+      compatible: 7.0,7.1,7.2,7.2.4,7.2.5,7.3,12.3,12.5.3
       incompatible:
     charge: free
     date: 2015-10-16

--- a/ldap/module/ldap/control.php
+++ b/ldap/module/ldap/control.php
@@ -31,13 +31,23 @@ class ldap extends control
 
     public function setting() 
     {
+    	$groups    = $this->dao->select('id, name, role')->from(TABLE_GROUP)->fetchAll();
+        $groupList = array('' => '');
+        foreach($groups as $group)
+        {
+            $groupList[$group->id] = $group->name;
+        }
+	
         $this->view->title      = $this->lang->ldap->common . $this->lang->colon . $this->lang->ldap->setting;
         $this->view->position[] = html::a(inlink('index'), $this->lang->ldap->common);
         $this->view->position[] = $this->lang->ldap->setting;
 
+		$this->view->group  = $this->config->ldap->group; // 用于显示权限分组选项，供用户自行选择
+		$this->view->groupList  = $groupList;
+
         $this->display();
     }
-
+ 
     public function save()
     {
         if (!empty($_POST)) {
@@ -50,6 +60,7 @@ class ldap extends control
             $this->config->ldap->uid = $this->post->ldapAttr;
             $this->config->ldap->mail = $this->post->ldapMail;
             $this->config->ldap->name = $this->post->ldapName;
+            $this->config->ldap->group = $this->post->group;
 
             // 此处我们把配置写入配置文件
             $ldapConfig = "<?php \n"
@@ -62,7 +73,8 @@ class ldap extends control
                           ."\$config->ldap->searchFilter = '{$this->post->ldapFilter}';\n"
                           ."\$config->ldap->uid = '{$this->post->ldapAttr}';\n"
                           ."\$config->ldap->mail = '{$this->post->ldapMail}';\n"
-                          ."\$config->ldap->name = '{$this->post->ldapName}';\n";
+                          ."\$config->ldap->name = '{$this->post->ldapName}';\n"
+                          ."\$config->ldap->group = '{$this->post->group}';\n";
 
             $file = fopen("config.php", "w") or die("Unable to open file!");
             fwrite($file, $ldapConfig); 

--- a/ldap/module/ldap/lang/en.php
+++ b/ldap/module/ldap/lang/en.php
@@ -23,6 +23,9 @@ $lang->ldap->save 			= 'Save';
 $lang->ldap->test 			= 'Connect Test';
 $lang->ldap->mail 			= 'EMail:';
 $lang->ldap->name  			= 'Name Attrubte:';
+$lang->ldap->group  			= 'Default Group:';
+
+$lang->ldap->placeholder->group 	= 'Add a default group to users who have passed through LDAP.';
 
 $lang->ldap->methodOrder[5] = 'index';
 $lang->ldap->methodOrder[10] = 'setting';

--- a/ldap/module/ldap/lang/zh-cn.php
+++ b/ldap/module/ldap/lang/zh-cn.php
@@ -24,6 +24,9 @@ $lang->ldap->save 			= '保存设置';
 $lang->ldap->test 			= '测试连接';
 $lang->ldap->mail 			= 'EMail 字段:';
 $lang->ldap->name  			= '姓名字段:';
+$lang->ldap->group  			= '默认权限:';
+
+$lang->ldap->placeholder->group 	= '为从ldap通过过来的用户添加一个默认权限';
 
 $lang->ldap->methodOrder[5] = 'index';
 $lang->ldap->methodOrder[10] = 'setting';

--- a/ldap/module/ldap/lang/zh-tw.php
+++ b/ldap/module/ldap/lang/zh-tw.php
@@ -23,6 +23,9 @@ $lang->ldap->save 			= '保存设置';
 $lang->ldap->test 			= '测试连接';
 $lang->ldap->mail 			= 'EMail 字段:';
 $lang->ldap->name  			= '姓名字段:';
+$lang->ldap->group  			= '默認許可權:';
+
+$lang->ldap->placeholder->group 	= '為從ldap通過過來的用戶添加一個默認許可權';
 
 $lang->ldap->methodOrder[5] = 'index';
 $lang->ldap->methodOrder[10] = 'setting';

--- a/ldap/module/ldap/model.php
+++ b/ldap/module/ldap/model.php
@@ -69,6 +69,7 @@ class ldapModel extends model
     {
         $ldapUsers = $this->getUsers($config);
         $user = new stdclass();
+        $group = new stdClass(); // 保存同步ldap数据设置的默认权限分组信息
         $account = '';
         $i=0;
         for (; $i < $ldapUsers['count']; $i++) {         
@@ -76,12 +77,16 @@ class ldapModel extends model
             $user->email = $ldapUsers[$i][$config->mail][0];
             $user->realname = $ldapUsers[$i][$config->name][0];
 
+            $group->account = $ldapUsers[$i][$config->uid][0];
+			$group->group = (!empty($config->group) ? $config->group : $this->config->ldap->group); //由于默认权限分组标识不在ldap内存储，所以直接从config中拿。为了兼容zentao自带定时任务所以用了三目运算符
             $account = $this->dao->select('*')->from(TABLE_USER)->where('account')->eq($user->account)->fetch('account');
             if ($account == $user->account) {
                 $this->dao->update(TABLE_USER)->data($user)->where('account')->eq($user->account)->autoCheck()->exec();
             } else {
-                $this->dao->insert(TABLE_USER)->data($user)->autoCheck()->exec();
+                $this->dao->insert(TABLE_USER)->data($user)->exec();
+            	$this->dao->insert(TABLE_USERGROUP)->data($group)->exec();
             }
+
 
             if(dao::isError()) 
             {

--- a/ldap/module/ldap/view/setting.html.php
+++ b/ldap/module/ldap/view/setting.html.php
@@ -65,6 +65,11 @@ include '../../common/view/header.html.php';
         <td class='w-p50'><?php echo html::input('ldapName', $config->ldap->name, "class='form-control'");?></td>
       </tr>
       <tr>
+        <th class='w-p25'><?php echo $lang->ldap->group; ?></th>
+		<td class='w-p50'><?php echo html::select('group', $groupList, (!empty($group) ? $group : ''), "class='form-control chosen'");?></td>
+		<td><?php echo $lang->ldap->placeholder->group;?></td>
+      </tr>
+      <tr>
         <td class='w-p25'></td>
         <td class="text-center">
           <?php 


### PR DESCRIPTION
感谢大大将插件修改成12.3可用，我这边使用12.5.3也能正常使用。我这边在同步界面新增了默认权限分组选项，这样从ldap同步过去的用户就会默认拥有一个权限，系统管理员就不用手动为每个用户单独设置权限。另外查看12.5.3版本的定时任务功能说明，发现zentao可以进行定时ldap插件的sync方法已完成定时从ldap获取数据，格式`moduleName=ldap&methodName=sync`。但是module中同样缺少对内部调用实现同步权限分组的兼容处置，本次也做了处理。另外在调试定时任务的时候发现zentao在调用对应模块的时候需要重启定时任务，不然对代码的修改将不生效。感谢大佬。